### PR TITLE
Position with props

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ React.render(
   document.body
 );
 ```
+### Optional Props
+
+By default, the meter is fixed positioned in the bottom right.
+You can pass the optional props `top`, `right`, `bottom` & `left`
+to overrride that positioning. `bottom` & `right` have values by
+default, so pass `'auto'` as their values if you want to use `left`
+or `top` values.
+

--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ var padding = 5;
 var style = {
   zIndex: 999999,
   position: 'fixed',
-  bottom: '5px',
-  right: '5px',
   height: '46px',
   width: (graphWidth + 6) + 'px',
   padding: '3px',
@@ -40,12 +38,20 @@ var graphStyle = {
 var FPSStats = React.createClass({
 
   propTypes: {
-    isActive: React.PropTypes.bool
+    isActive: React.PropTypes.bool,
+    top: React.PropTypes.string,
+    bottom: React.PropTypes.string,
+    right: React.PropTypes.string,
+    left: React.PropTypes.string
   },
 
   getDefaultProps: function() {
     return {
-      isActive: true
+      isActive: true,
+      top: 'auto'
+      bottom: '5px',
+      right: '5px',
+      left: 'auto'
     };
   },
 
@@ -62,6 +68,13 @@ var FPSStats = React.createClass({
 
   shouldComponentUpdate: function(nextProps, nextState) {
     return this.state.fps !== nextState.fps;
+  },
+
+  componentWillMount: function() {
+    style.top = this.props.top;
+    style.right = this.props.right;
+    style.bottom = this.props.bottom;
+    style.left = this.props.left;
   },
 
   componentDidMount: function() {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ var style = {
   fontFamily: 'Helvetica, Arial, sans-serif',
   fontWeight: 'bold',
   MozBoxSizing: 'border-box',
-  boxSizing: 'border-box'
+  boxSizing: 'border-box',
+  pointerEvents: 'none'
 };
 
 var graphStyle = {
@@ -48,7 +49,7 @@ var FPSStats = React.createClass({
   getDefaultProps: function() {
     return {
       isActive: true,
-      top: 'auto'
+      top: 'auto',
       bottom: '5px',
       right: '5px',
       left: 'auto'


### PR DESCRIPTION
Allow `top`, `right`, `bottom` & `left` to be passed as props (but default to their current values when not passed).

Set `pointer-events: none` to allow clicks to pass through on browsers that support the `pointer-events` css rules.
