### PR TITLE
Fixes console warning caused by bottom: '0'

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ var FPSStats = React.createClass({
 
       var graphItemStyle = {
         position: 'absolute',
-        bottom: '0',
+        bottom: 0,
         right: (that.state.fps.length -1 - i) + 'px',
         height: height + 'px',
         width: '1px',


### PR DESCRIPTION
warning.js:44 Warning: a `div` tag (owner: `Constructor`) was passed a numeric string value for CSS property `bottom` (value: `0`) which will be treated as a unitless number in a future version of React.
